### PR TITLE
feat: 쿠폰 만료 스케줄러, API 구현

### DIFF
--- a/src/main/java/one/theone/server/common/config/security/SecurityConfig.java
+++ b/src/main/java/one/theone/server/common/config/security/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/signup", "/api/login").permitAll()
 
                         //region 쿠폰 관련
-                        .requestMatchers("/api/admin/coupons").hasRole("ADMIN")
+                        .requestMatchers("/api/admin/coupons/**").hasRole("ADMIN")
                         .requestMatchers("/api/admin/member/*/coupons/*/recall").hasRole("ADMIN")
                         //endregion
 

--- a/src/main/java/one/theone/server/common/exception/domain/CouponExceptionEnum.java
+++ b/src/main/java/one/theone/server/common/exception/domain/CouponExceptionEnum.java
@@ -18,6 +18,7 @@ public enum CouponExceptionEnum implements ErrorCode {
     , ERR_MEMBER_COUPON_ALREADY_RECALLED(HttpStatus.BAD_REQUEST, "이미 회수된 쿠폰입니다")
     , ERR_AMOUNT_COUPON_DISCOUNT_VALUE_MIN(HttpStatus.BAD_REQUEST, "금액 할인 쿠폰의 할인 금액은 5000원 이상 부터 가능합니다")
     , ERR_RATE_COUPON_DISCOUNT_VALUE_MAX(HttpStatus.BAD_REQUEST, "정률 할인 쿠폰의 할인율은 100% 이하여야 합니다")
+    , ERR_COUPON_END_AT_BEFORE_START_AT(HttpStatus.BAD_REQUEST, "쿠폰 종료일은 시작일 이후여야 합니다")
     , ERR_COUPON_LOCK_FAILED(HttpStatus.CONFLICT, "잠시 후 다시 시도해주세요");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/one/theone/server/domain/coupon/controller/CouponController.java
+++ b/src/main/java/one/theone/server/domain/coupon/controller/CouponController.java
@@ -92,6 +92,15 @@ public class CouponController {
                         couponIssueService.issueCouponWithLock(couponId, memberId, request.eventId())));
     }
 
+    @PatchMapping("/api/admin/coupons/{couponId}/expire")
+    public ResponseEntity<BaseResponse<CouponExpireResponse>> expireCoupon(
+            @PathVariable Long couponId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.success(HttpStatus.OK.name(), "쿠폰 만료 처리 성공",
+                        couponService.expireCoupon(couponId)));
+    }
+
     @PatchMapping("/api/admin/member/{memberId}/coupons/{memberCouponId}/recall")
     public ResponseEntity<BaseResponse<CouponRecallResponse>> recallCoupon(
             @PathVariable Long memberId,

--- a/src/main/java/one/theone/server/domain/coupon/dto/request/CouponCreateRequest.java
+++ b/src/main/java/one/theone/server/domain/coupon/dto/request/CouponCreateRequest.java
@@ -3,6 +3,7 @@ package one.theone.server.domain.coupon.dto.request;
 import jakarta.validation.constraints.*;
 import one.theone.server.domain.coupon.entity.Coupon;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record CouponCreateRequest(
@@ -28,7 +29,8 @@ public record CouponCreateRequest(
         LocalDateTime startAt
 
         , @NotNull(message = "쿠폰 사용 종료일은 필수입니다")
-        LocalDateTime endAt
+        @Future(message = "쿠폰 사용 종료일은 내일 이후여야 합니다")
+        LocalDate endAt
 ) {
 
 }

--- a/src/main/java/one/theone/server/domain/coupon/dto/response/CouponExpireResponse.java
+++ b/src/main/java/one/theone/server/domain/coupon/dto/response/CouponExpireResponse.java
@@ -1,0 +1,7 @@
+package one.theone.server.domain.coupon.dto.response;
+
+public record CouponExpireResponse(
+        Long couponId,
+        int expiredCount
+) {
+}

--- a/src/main/java/one/theone/server/domain/coupon/entity/Coupon.java
+++ b/src/main/java/one/theone/server/domain/coupon/entity/Coupon.java
@@ -8,6 +8,7 @@ import one.theone.server.common.entity.BaseEntity;
 import one.theone.server.common.exception.ServiceErrorException;
 import one.theone.server.common.exception.domain.CouponExceptionEnum;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -50,7 +51,7 @@ public class Coupon extends BaseEntity {
     private LocalDateTime deleted_at;
 
     public static Coupon register(String name, CouponUseType useType, Long minPrice, Long discountValue,
-                                  Long availQuantity, LocalDateTime startAt, LocalDateTime endAt) {
+                                  Long availQuantity, LocalDateTime startAt, LocalDate endAt) {
         Coupon coupon = new Coupon();
         coupon.name = name;
         coupon.useType = useType;
@@ -59,7 +60,7 @@ public class Coupon extends BaseEntity {
         coupon.availQuantity = availQuantity;
         coupon.issuedQuantity = 0L;
         coupon.startAt = startAt;
-        coupon.endAt = endAt;
+        coupon.endAt = endAt.atTime(4, 59, 59);
         coupon.deleted = false;
         return coupon;
     }

--- a/src/main/java/one/theone/server/domain/coupon/repository/CouponQueryRepository.java
+++ b/src/main/java/one/theone/server/domain/coupon/repository/CouponQueryRepository.java
@@ -9,10 +9,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface CouponQueryRepository {
     Page<CouponSearchResponse> findAllCoupons(Coupon.CouponUseType useType, LocalDateTime startAt, LocalDateTime endAt, Pageable pageable);
     Optional<CouponDetailResponse> findCouponDetail(Long couponId);
     Page<CouponSearchMeResponse> findMyCoupons(Long memberId, MemberCoupon.MemberCouponStatus status, Pageable pageable);
+    List<MemberCoupon> findExpiredMemberCoupons(LocalDateTime now);
 }

--- a/src/main/java/one/theone/server/domain/coupon/repository/CouponQueryRepositoryImpl.java
+++ b/src/main/java/one/theone/server/domain/coupon/repository/CouponQueryRepositoryImpl.java
@@ -154,6 +154,20 @@ public class CouponQueryRepositoryImpl implements CouponQueryRepository {
         return new PageImpl<>(content, pageable, total);
     }
 
+    @Override
+    public List<MemberCoupon> findExpiredMemberCoupons(LocalDateTime expiredAt) {
+        return queryFactory
+                .selectFrom(memberCoupon)
+                .join(coupon).on(coupon.id.eq(memberCoupon.couponId))
+                .where(
+                        memberCoupon.status.eq(MemberCoupon.MemberCouponStatus.AVAILABLE)
+                        , coupon.endAt.lt(expiredAt)
+                        , coupon.deleted.isFalse()
+                        , memberCoupon.deleted.isFalse()
+                )
+                .fetch();
+    }
+
     private BooleanExpression useTypeEq(Coupon.CouponUseType useType) {
         return useType != null ? coupon.useType.eq(useType) : null;
     }

--- a/src/main/java/one/theone/server/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/one/theone/server/domain/coupon/repository/CouponRepository.java
@@ -3,5 +3,6 @@ package one.theone.server.domain.coupon.repository;
 import one.theone.server.domain.coupon.entity.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CouponRepository extends JpaRepository<Coupon, Long>, CouponQueryRepository {
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
 }

--- a/src/main/java/one/theone/server/domain/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/one/theone/server/domain/coupon/repository/MemberCouponRepository.java
@@ -3,9 +3,11 @@ package one.theone.server.domain.coupon.repository;
 import one.theone.server.domain.coupon.entity.MemberCoupon;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
-    boolean existsByMemberIdAndCouponIdAndStatus(Long memberId, Long couponId, MemberCoupon.MemberCouponStatus status);
-    Optional<MemberCoupon> findByIdAndMemberId(Long id, Long memberId);
+    boolean existsByMemberIdAndCouponIdAndStatusAndDeletedFalse(Long memberId, Long couponId, MemberCoupon.MemberCouponStatus status);
+    Optional<MemberCoupon> findByIdAndMemberIdAndDeletedFalse(Long id, Long memberId);
+    List<MemberCoupon> findAllByCouponIdAndStatusAndDeletedFalse(Long couponId, MemberCoupon.MemberCouponStatus status);
 }

--- a/src/main/java/one/theone/server/domain/coupon/scheduler/CouponExpireScheduler.java
+++ b/src/main/java/one/theone/server/domain/coupon/scheduler/CouponExpireScheduler.java
@@ -1,0 +1,36 @@
+package one.theone.server.domain.coupon.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import one.theone.server.domain.coupon.entity.Coupon;
+import one.theone.server.domain.coupon.entity.MemberCoupon;
+import one.theone.server.domain.coupon.repository.CouponQueryRepository;
+import one.theone.server.domain.coupon.repository.CouponRepository;
+import one.theone.server.domain.coupon.repository.MemberCouponRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponExpireScheduler {
+    private final CouponQueryRepository couponQueryRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 5 * * *")
+    public void expireCouponSchedule() {
+        log.info("쿠폰 만료 스케줄러 작동");
+        List<MemberCoupon> expireCouponList = couponQueryRepository.findExpiredMemberCoupons(LocalDateTime.now());
+
+        if(expireCouponList.isEmpty()){
+            return;
+        }
+
+        log.info("만료 처리 쿠폰 수 : {}", expireCouponList.size());
+        expireCouponList.forEach(coupon -> coupon.expireCoupon());
+    }
+}

--- a/src/main/java/one/theone/server/domain/coupon/service/CouponService.java
+++ b/src/main/java/one/theone/server/domain/coupon/service/CouponService.java
@@ -9,12 +9,14 @@ import one.theone.server.domain.coupon.dto.request.CouponIssueEventRequest;
 import one.theone.server.domain.coupon.dto.request.CouponIssueAdminRequest;
 import one.theone.server.domain.coupon.dto.response.CouponCreateResponse;
 import one.theone.server.domain.coupon.dto.response.CouponDetailResponse;
+import one.theone.server.domain.coupon.dto.response.CouponExpireResponse;
 import one.theone.server.domain.coupon.dto.response.CouponIssueResponse;
 import one.theone.server.domain.coupon.dto.response.CouponRecallResponse;
 import one.theone.server.domain.coupon.dto.response.CouponSearchMeResponse;
 import one.theone.server.domain.coupon.dto.response.CouponSearchResponse;
 import one.theone.server.domain.coupon.entity.Coupon;
 import one.theone.server.domain.coupon.entity.MemberCoupon;
+import one.theone.server.domain.coupon.repository.CouponQueryRepository;
 import one.theone.server.domain.coupon.repository.CouponRepository;
 import one.theone.server.domain.coupon.repository.MemberCouponRepository;
 import one.theone.server.domain.member.repository.MemberRepository;
@@ -26,8 +28,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static one.theone.server.common.exception.domain.CouponExceptionEnum.ERR_AMOUNT_COUPON_DISCOUNT_VALUE_MIN;
+import static one.theone.server.common.exception.domain.CouponExceptionEnum.ERR_COUPON_END_AT_BEFORE_START_AT;
 import static one.theone.server.common.exception.domain.CouponExceptionEnum.ERR_RATE_COUPON_DISCOUNT_VALUE_MAX;
 
 @Service
@@ -36,6 +40,7 @@ public class CouponService {
 
     private final CouponRepository couponRepository;
     private final MemberCouponRepository memberCouponRepository;
+    private final CouponQueryRepository couponQueryRepository;
     private final MemberRepository memberRepository;
 
     @Transactional
@@ -50,6 +55,10 @@ public class CouponService {
             if(request.discountValue() > 100) {
                 throw new ServiceErrorException(ERR_RATE_COUPON_DISCOUNT_VALUE_MAX);
             }
+        }
+
+        if (!request.endAt().isAfter(request.startAt().toLocalDate())) {
+            throw new ServiceErrorException(ERR_COUPON_END_AT_BEFORE_START_AT);
         }
 
         Coupon coupon = Coupon.register(
@@ -102,7 +111,7 @@ public class CouponService {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new ServiceErrorException(ERR_MEMBER_NOT_FOUND));
 
-        if (memberCouponRepository.existsByMemberIdAndCouponIdAndStatus(
+        if (memberCouponRepository.existsByMemberIdAndCouponIdAndStatusAndDeletedFalse(
                 memberId, couponId, MemberCoupon.MemberCouponStatus.AVAILABLE)) {
             throw new ServiceErrorException(ERR_COUPON_ALREADY_ISSUED);
         }
@@ -112,24 +121,36 @@ public class CouponService {
 
     @Transactional(readOnly = true)
     public PageResponse<CouponSearchResponse> getCoupons(Coupon.CouponUseType useType, LocalDateTime startAt, LocalDateTime endAt, Pageable pageable) {
-        Page<CouponSearchResponse> page = couponRepository.findAllCoupons(useType, startAt, endAt, pageable);
+        Page<CouponSearchResponse> page = couponQueryRepository.findAllCoupons(useType, startAt, endAt, pageable);
         return PageResponse.register(page);
     }
 
     @Transactional(readOnly = true)
     public CouponDetailResponse getCouponDetails(Long couponId) {
-        return couponRepository.findCouponDetail(couponId).orElseThrow(() -> new ServiceErrorException(CouponExceptionEnum.ERR_COUPON_NOT_FOUND));
+        return couponQueryRepository.findCouponDetail(couponId).orElseThrow(() -> new ServiceErrorException(CouponExceptionEnum.ERR_COUPON_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
     public PageResponse<CouponSearchMeResponse> getMyCoupons(Long memberId, MemberCoupon.MemberCouponStatus status, Pageable pageable) {
-        Page<CouponSearchMeResponse> page = couponRepository.findMyCoupons(memberId, status, pageable);
+        Page<CouponSearchMeResponse> page = couponQueryRepository.findMyCoupons(memberId, status, pageable);
         return PageResponse.register(page);
     }
 
     @Transactional
+    public CouponExpireResponse expireCoupon(Long couponId) {
+        couponRepository.findById(couponId)
+                .orElseThrow(() -> new ServiceErrorException(CouponExceptionEnum.ERR_COUPON_NOT_FOUND));
+
+        List<MemberCoupon> memberCouponList = memberCouponRepository.findAllByCouponIdAndStatusAndDeletedFalse(
+                couponId, MemberCoupon.MemberCouponStatus.AVAILABLE);
+        memberCouponList.forEach(memberCoupon -> memberCoupon.expireCoupon());
+
+        return new CouponExpireResponse(couponId, memberCouponList.size());
+    }
+
+    @Transactional
     public CouponRecallResponse recallCoupon(Long memberId, Long memberCouponId) {
-        MemberCoupon memberCoupon = memberCouponRepository.findByIdAndMemberId(memberCouponId, memberId)
+        MemberCoupon memberCoupon = memberCouponRepository.findByIdAndMemberIdAndDeletedFalse(memberCouponId, memberId)
                 .orElseThrow(() -> new ServiceErrorException(CouponExceptionEnum.ERR_MEMBER_COUPON_NOT_FOUND));
 
         memberCoupon.recallByAdmin();

--- a/src/test/java/one/theone/server/domain/coupon/service/CouponIssueServiceTest.java
+++ b/src/test/java/one/theone/server/domain/coupon/service/CouponIssueServiceTest.java
@@ -20,6 +20,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,14 +70,15 @@ public class CouponIssueServiceTest {
     void setUp() {
         // 발급 수량 100개 쿠폰 생성
         Coupon coupon = couponRepository.save(Coupon.register(
-                "TEST_COUPON",
-                Coupon.CouponUseType.AMOUNT,
-                10000L,
-                5000L,
-                100L,
-                LocalDateTime.now().minusDays(1),
-                LocalDateTime.now().plusDays(7)
+                "TEST_COUPON"
+                , Coupon.CouponUseType.AMOUNT
+                , 10000L
+                , 5000L
+                , 100L
+                , LocalDateTime.now().minusDays(1)
+                , LocalDate.now().plusDays(7)
         ));
+
         couponId = coupon.getId();
 
         // 100명 회원 생성


### PR DESCRIPTION
refactor: 쿠폰 종료일자 지정 규칙 변경 (일자지정 일시고정)

# Work History
### 쿠폰 만료 스케줄러, API 구현
  -  쿠폰 만료 스케줄러, API 구현
  - 쿠폰 종료일자 지정 규칙 변경 (일자지정 일시고정)

# ETC
쿠폰 종료 일자를 지정 (04:59:59 지정)
스케줄러가 5시에 작동하며 만료