### PR TITLE
feat : 리프레쉬 토큰 발급 API 추가

### DIFF
--- a/src/main/java/one/theone/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/one/theone/server/domain/auth/controller/AuthController.java
@@ -5,14 +5,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import one.theone.server.common.dto.BaseResponse;
 import one.theone.server.domain.auth.dto.LoginRequest;
+import one.theone.server.domain.auth.dto.ReissueRequest;
 import one.theone.server.domain.auth.dto.TokenResponse;
 import one.theone.server.domain.auth.service.AuthService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api")
@@ -21,6 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+
+    @PostMapping("/reissue")
+    public BaseResponse<TokenResponse> reissue(@Valid @RequestBody ReissueRequest request) {
+        TokenResponse response = authService.reissue(request.refreshToken(), request.memberId());
+        return BaseResponse.success("200", "토큰 재발급 완료", response);
+    }
 
      //로그인 API - 성공 시 Access/Refresh Token 발급
      //실패 시 Redis에 기록하여 3회 실패 시 30초 차단

--- a/src/main/java/one/theone/server/domain/auth/dto/ReissueRequest.java
+++ b/src/main/java/one/theone/server/domain/auth/dto/ReissueRequest.java
@@ -1,0 +1,9 @@
+package one.theone.server.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ReissueRequest(
+        @NotBlank String refreshToken,
+        @NotNull Long memberId
+) {}

--- a/src/main/java/one/theone/server/domain/auth/service/AuthService.java
+++ b/src/main/java/one/theone/server/domain/auth/service/AuthService.java
@@ -30,6 +30,33 @@ public class AuthService {
     private static final int MAX_FAIL_COUNT = 3;
     private static final long LOCK_TIME = 30; // 30초 차단
 
+    @Transactional
+    public TokenResponse reissue(String oldRefreshToken, Long memberId) {
+        //Redis에서 저장된 리프레시 토큰 가져오기
+        String savedToken = (String) redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + memberId);
+
+        //검증: 클라이언트가 보낸 토큰이 Redis에 있는 것과 일치하는지
+        if (savedToken == null || !savedToken.equals(oldRefreshToken)) {
+            throw new ServiceErrorException(MemberExceptionEnum.ERR_UNAUTHORIZED_ACCESS);
+        }
+
+        //새 토큰 생성
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ServiceErrorException(MemberExceptionEnum.ERR_MEMBER_NOT_FOUND));
+
+        String newAccessToken = jwtProvider.createAccessToken(member.getId(), member.getRole().name());
+        String newRefreshToken = jwtProvider.createRefreshToken();
+
+        //Redis 갱신 (Refresh Token Rotation)
+        redisTemplate.opsForValue().set(
+                REFRESH_TOKEN_PREFIX + member.getId(),
+                newRefreshToken,
+                7, TimeUnit.DAYS
+        );
+
+        return new TokenResponse(newAccessToken, newRefreshToken);
+    }
+
     @PostConstruct
     public void checkRedis() {
         try {


### PR DESCRIPTION
Work History
JWT Refresh Token 재발급(Reissue) 기능 및 보안 로직 구현
토큰 재발급 API 구현: Access Token 만료 시 사용자 재로그인 없이 권한을 연장할 수 있는 /api/reissue 엔드포인트 구축

Redis 연동 보안 강화: 로그인 시 Refresh Token을 Redis에 저장(7일 유지)하여 서버 측에서 세션 제어권 확보

Refresh Token Rotation 적용: 재발급 요청 시 기존 Refresh Token을 폐기하고 신규 Access/Refresh 토큰 세트를 재발급하여 토큰 탈취 시나리오 방어

보안 검증 로직: 클라이언트 전송 토큰과 Redis 저장 토큰의 일치 여부를 대조하여 부정 요청 차단

Releated Issue
Resolves (#issue_number)

ETC
테스트 방법:

/api/login 호출로 토큰 A세트 획득.

/api/reissue에 A세트의 refreshToken 전송 시, 값이 변경된 B세트 토큰 수신 확인.

이미 사용된 A세트의 리프레시 토큰으로 재요청 시 ERR_UNAUTHORIZED_ACCESS 에러 발생 확인 (정상).